### PR TITLE
Support multiple scopes in the authorization_uri

### DIFF
--- a/lib/apple_id/client.rb
+++ b/lib/apple_id/client.rb
@@ -17,6 +17,21 @@ module AppleID
       super :body, options
     end
 
+    def authorization_uri(params = {})
+      # NOTE:
+      # Apple keychain (native window) does not support space encoding
+      # with '+' in url params. We have to use '%20' otherwise multiple
+      # scopes will be ignored. (no email / name will be returned)
+      uri = super(params.except(:scope))
+      if params[:scope]
+        scope_as_string = Array(params[:scope]).join(' ')
+        scope_param = "&scope=#{URI.encode(scope_as_string)}"
+        uri << scope_param
+      end
+
+      uri
+    end
+
     private
 
     def client_secret_jwt

--- a/spec/apple_id/client_spec.rb
+++ b/spec/apple_id/client_spec.rb
@@ -26,8 +26,12 @@ RSpec.describe AppleID::Client do
       }.reject do |k,v|
         v.blank?
       end
-      query = URI.parse(client.authorization_uri params).query
-      Rack::Utils.parse_query(query).with_indifferent_access
+      URI.parse(client.authorization_uri params).
+        query.
+        split('&').
+        map { |param| param.split('=') }.
+        to_h.
+        with_indifferent_access
     end
 
     describe 'scope' do
@@ -37,6 +41,38 @@ RSpec.describe AppleID::Client do
 
       context 'as default' do
         it { should == nil }
+      end
+
+      describe 'String type' do
+        context 'single scope' do
+          let(:scope) { 'email' }
+
+          it { should == 'email' }
+        end
+
+        context 'multiple scopes' do
+          let(:scope) { 'email name' }
+
+          it 'url encodes space character' do
+            should == 'email%20name'
+          end
+        end
+      end
+
+      describe 'Array type' do
+        context 'single scope' do
+          let(:scope) { [:email] }
+
+          it { should == 'email' }
+        end
+
+        context 'multiple scopes' do
+          let(:scope) { [:email, :name] }
+
+          it 'url encodes space character' do
+            should == 'email%20name'
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Apple keychain (native dialog that popups when safari is used)
does not support space encoding with '+' in url params.
We have to use '%20' otherwise multiple scopes will be ignored.
(no email / name will be returned)